### PR TITLE
Generalise mock data

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -30,9 +30,9 @@ describe("App Component", () => {
       expect(screen.getByText("Test Portfolio")).toBeInTheDocument();
       expect(screen.getByText("Home")).toBeInTheDocument();
       expect(screen.getByText("Experience")).toBeInTheDocument();
-      expect(screen.getByText("Projects")).toBeInTheDocument();
-      expect(screen.getByText("GitHub")).toBeInTheDocument();
-      expect(screen.getByText("LinkedIn")).toBeInTheDocument();
+      expect(screen.getByText("Link 1")).toBeInTheDocument();
+      expect(screen.getByText("Link 2")).toBeInTheDocument();
+      expect(screen.getByText("Link 3")).toBeInTheDocument();
     });
   });
 
@@ -87,18 +87,18 @@ describe("App Component", () => {
       renderWithProviders(<App />, { store });
 
       // Check social links
-      expect(screen.getByText("GitHub")).toBeInTheDocument();
-      expect(screen.getByText("LinkedIn")).toBeInTheDocument();
+      expect(screen.getByText("Link 1")).toBeInTheDocument();
+      expect(screen.getByText("Link 2")).toBeInTheDocument();
+      expect(screen.getByText("Link 3")).toBeInTheDocument();
 
       // Verify they are links
-      const githubLink = screen.getByText("GitHub").closest("a");
-      const linkedinLink = screen.getByText("LinkedIn").closest("a");
+      const link1 = screen.getByText("Link 1").closest("a");
+      const link2 = screen.getByText("Link 2").closest("a");
+      const link3 = screen.getByText("Link 3").closest("a");
 
-      expect(githubLink).toHaveAttribute("href", "https://github.com/testuser");
-      expect(linkedinLink).toHaveAttribute(
-        "href",
-        "https://linkedin.com/in/testuser"
-      );
+      expect(link1).toHaveAttribute("href", "https://link1.com");
+      expect(link2).toHaveAttribute("href", "https://link2.com");
+      expect(link3).toHaveAttribute("href", "https://link3.com");
     });
   });
 

--- a/src/components/common/Footer.test.tsx
+++ b/src/components/common/Footer.test.tsx
@@ -12,24 +12,21 @@ describe("Footer", () => {
   it("renders SocialLinkButton for each social link", () => {
     renderWithTheme(<Footer {...mockProps} />);
 
-    expect(screen.getByText("GitHub")).toBeInTheDocument();
-    expect(screen.getByText("LinkedIn")).toBeInTheDocument();
-    expect(screen.getByText("Twitter")).toBeInTheDocument();
+    expect(screen.getByText("Link 1")).toBeInTheDocument();
+    expect(screen.getByText("Link 2")).toBeInTheDocument();
+    expect(screen.getByText("Link 3")).toBeInTheDocument();
 
-    const githubLink = screen.getByText("GitHub").closest("a");
-    const linkedinLink = screen.getByText("LinkedIn").closest("a");
-    const twitterLink = screen.getByText("Twitter").closest("a");
+    const link1 = screen.getByText("Link 1").closest("a");
+    const link2 = screen.getByText("Link 2").closest("a");
+    const link3 = screen.getByText("Link 3").closest("a");
 
-    expect(githubLink).toBeInTheDocument();
-    expect(linkedinLink).toBeInTheDocument();
-    expect(twitterLink).toBeInTheDocument();
+    expect(link1).toBeInTheDocument();
+    expect(link2).toBeInTheDocument();
+    expect(link3).toBeInTheDocument();
 
-    expect(githubLink).toHaveAttribute("href", "https://github.com/testuser");
-    expect(linkedinLink).toHaveAttribute(
-      "href",
-      "https://linkedin.com/in/testuser"
-    );
-    expect(twitterLink).toHaveAttribute("href", "https://twitter.com/testuser");
+    expect(link1).toHaveAttribute("href", "https://link1.com");
+    expect(link2).toHaveAttribute("href", "https://link2.com");
+    expect(link3).toHaveAttribute("href", "https://link3.com");
   });
 
   it("renders footer with correct styling structure", () => {

--- a/src/components/common/SocialLinkButton.test.tsx
+++ b/src/components/common/SocialLinkButton.test.tsx
@@ -3,7 +3,7 @@ import { mockSocialLinks, renderWithTheme } from "../../test-utils";
 import SocialLinkButton from "./SocialLinkButton";
 
 describe("SocialLinkButton", () => {
-  const mockLink = mockSocialLinks.github();
+  const mockLink = mockSocialLinks.link_1();
 
   const mockProps = {
     link: mockLink,
@@ -11,7 +11,7 @@ describe("SocialLinkButton", () => {
 
   it("displays the link name", () => {
     renderWithTheme(<SocialLinkButton {...mockProps} />);
-    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByText("Link 1")).toBeInTheDocument();
   });
 
   it("renders as an anchor element with correct href", () => {
@@ -19,7 +19,7 @@ describe("SocialLinkButton", () => {
 
     const linkElement = screen.getByRole("link");
     expect(linkElement).toBeInTheDocument();
-    expect(linkElement).toHaveAttribute("href", "https://github.com/testuser");
+    expect(linkElement).toHaveAttribute("href", "https://link1.com");
   });
 
   it("opens link in new tab with correct security attributes", () => {
@@ -45,7 +45,7 @@ describe("SocialLinkButton", () => {
   it("maintains accessibility by providing clickable text", () => {
     renderWithTheme(<SocialLinkButton {...mockProps} />);
 
-    const linkElement = screen.getByRole("link", { name: "GitHub" });
+    const linkElement = screen.getByRole("link", { name: "Link 1" });
     expect(linkElement).toBeInTheDocument();
     expect(linkElement).toBeVisible();
   });

--- a/src/components/experience/ExperiencePanel.test.tsx
+++ b/src/components/experience/ExperiencePanel.test.tsx
@@ -8,7 +8,7 @@ import ExperiencePanel from "./ExperiencePanel";
 
 describe("ExperiencePanel", () => {
   const professionalExperience = mockProfessionalExperience.experience_1();
-  const academicExperience = mockAcademicExperience.university();
+  const academicExperience = mockAcademicExperience.experience_1();
   const professionalExperienceNoProjects =
     mockProfessionalExperience.noProjects();
 
@@ -66,30 +66,26 @@ describe("ExperiencePanel", () => {
     it("displays institution name", () => {
       renderWithTheme(<ExperiencePanel {...mockProps} />);
 
-      expect(screen.getByText("University of Technology")).toBeInTheDocument();
+      expect(screen.getByText("Academic Institution 1")).toBeInTheDocument();
     });
 
     it("displays degree", () => {
       renderWithTheme(<ExperiencePanel {...mockProps} />);
 
-      expect(
-        screen.getByText("Bachelor of Computer Science")
-      ).toBeInTheDocument();
+      expect(screen.getByText("Academic Degree 1")).toBeInTheDocument();
     });
 
     it("displays date range", () => {
       renderWithTheme(<ExperiencePanel {...mockProps} />);
 
-      expect(screen.getByText("2018-09 - 2022-05")).toBeInTheDocument();
+      expect(screen.getByText("01/01/2018 - 01/01/2022")).toBeInTheDocument();
     });
 
     it("displays academic projects", () => {
       renderWithTheme(<ExperiencePanel {...mockProps} />);
 
-      expect(screen.getByText("Capstone Project")).toBeInTheDocument();
-      expect(
-        screen.getByText("Machine learning application for data analysis")
-      ).toBeInTheDocument();
+      expect(screen.getByText("Project 2")).toBeInTheDocument();
+      expect(screen.getByText("Project 2 description")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/experience/ExperiencePanel.test.tsx
+++ b/src/components/experience/ExperiencePanel.test.tsx
@@ -7,7 +7,7 @@ import {
 import ExperiencePanel from "./ExperiencePanel";
 
 describe("ExperiencePanel", () => {
-  const professionalExperience = mockProfessionalExperience.senior();
+  const professionalExperience = mockProfessionalExperience.experience_1();
   const academicExperience = mockAcademicExperience.university();
   const professionalExperienceNoProjects =
     mockProfessionalExperience.noProjects();
@@ -21,19 +21,19 @@ describe("ExperiencePanel", () => {
     it("displays company name", () => {
       renderWithTheme(<ExperiencePanel {...mockProps} />);
 
-      expect(screen.getByText("Tech Corp")).toBeInTheDocument();
+      expect(screen.getByText("Professional Company 1")).toBeInTheDocument();
     });
 
     it("displays position", () => {
       renderWithTheme(<ExperiencePanel {...mockProps} />);
 
-      expect(screen.getByText("Senior Software Engineer")).toBeInTheDocument();
+      expect(screen.getByText("Professional Position 1")).toBeInTheDocument();
     });
 
     it("displays date range", () => {
       renderWithTheme(<ExperiencePanel {...mockProps} />);
 
-      expect(screen.getByText("2022-01 - Present")).toBeInTheDocument();
+      expect(screen.getByText("01/01/2020 - Present")).toBeInTheDocument();
     });
 
     it("displays projects when available", () => {
@@ -51,8 +51,8 @@ describe("ExperiencePanel", () => {
 
       renderWithTheme(<ExperiencePanel {...mockPropsNoProjects} />);
 
-      expect(screen.getByText("Test Company")).toBeInTheDocument();
-      expect(screen.getByText("Software Engineer")).toBeInTheDocument();
+      expect(screen.getByText("No Projects Company")).toBeInTheDocument();
+      expect(screen.getByText("No Projects Position")).toBeInTheDocument();
       expect(screen.queryByText("Projects")).not.toBeInTheDocument();
     });
   });

--- a/src/components/experience/ExperiencePanel.test.tsx
+++ b/src/components/experience/ExperiencePanel.test.tsx
@@ -39,12 +39,8 @@ describe("ExperiencePanel", () => {
     it("displays projects when available", () => {
       renderWithTheme(<ExperiencePanel {...mockProps} />);
 
-      expect(screen.getByText("Advanced Web Application")).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          "Developed a complex web application using React and TypeScript with advanced features"
-        )
-      ).toBeInTheDocument();
+      expect(screen.getByText("Project 1")).toBeInTheDocument();
+      expect(screen.getByText("Project 1 description")).toBeInTheDocument();
     });
 
     it("handles experience with no projects", () => {

--- a/src/components/home/ProfileSummaryDisplay.test.tsx
+++ b/src/components/home/ProfileSummaryDisplay.test.tsx
@@ -12,15 +12,9 @@ describe("ProfileSummaryDisplay", () => {
   it("displays all profile description paragraphs", () => {
     renderWithTheme(<ProfileSummaryDisplay {...mockProps} />);
 
-    expect(
-      screen.getByText(/I am a passionate software developer/)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/I enjoy building user-friendly applications/)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Always eager to learn new technologies/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Profile summary line 1./)).toBeInTheDocument();
+    expect(screen.getByText(/Profile summary line 2./)).toBeInTheDocument();
+    expect(screen.getByText(/Profile summary line 3./)).toBeInTheDocument();
   });
 
   it("renders profile summary in a paragraph element", () => {

--- a/src/components/home/TechStack.test.tsx
+++ b/src/components/home/TechStack.test.tsx
@@ -28,9 +28,9 @@ describe("TechStack", () => {
   it("renders all technology buttons", () => {
     renderWithTheme(<TechStack {...mockProps} />);
 
-    expect(screen.getByText("React")).toBeInTheDocument();
-    expect(screen.getByText("TypeScript")).toBeInTheDocument();
-    expect(screen.getByText("Node.js")).toBeInTheDocument();
+    expect(screen.getByText("Technology 1")).toBeInTheDocument();
+    expect(screen.getByText("Technology 2")).toBeInTheDocument();
+    expect(screen.getByText("Technology 3")).toBeInTheDocument();
   });
 
   it("renders with correct container structure", () => {

--- a/src/components/home/TechnologyButton.test.tsx
+++ b/src/components/home/TechnologyButton.test.tsx
@@ -8,7 +8,7 @@ import {
 import TechnologyButton from "./TechnologyButton";
 
 describe("TechnologyButton", () => {
-  const mockTechnology = mockTechnologies.react();
+  const mockTechnology = mockTechnologies.tech_1();
 
   const mockProps = {
     technology: mockTechnology,
@@ -22,26 +22,26 @@ describe("TechnologyButton", () => {
   it("displays technology name", () => {
     renderWithTheme(<TechnologyButton {...mockProps} />);
 
-    expect(screen.getByText("React")).toBeInTheDocument();
+    expect(screen.getByText("Technology 1")).toBeInTheDocument();
   });
 
   it("renders technology icon with correct attributes", () => {
     renderWithTheme(<TechnologyButton {...mockProps} />);
 
-    const icon = screen.getByAltText("React icon");
+    const icon = screen.getByAltText("Technology 1 icon");
     expect(icon).toBeInTheDocument();
-    expect(icon).toHaveAttribute("src", "https://example.com/react-icon.svg");
-    expect(icon).toHaveAttribute("alt", "React icon");
+    expect(icon).toHaveAttribute("src", "tech1.svg");
+    expect(icon).toHaveAttribute("alt", "Technology 1 icon");
   });
 
   it("opens technology URL when clicked", () => {
     renderWithTheme(<TechnologyButton {...mockProps} />);
 
-    const button = screen.getByText("React").closest("div");
+    const button = screen.getByText("Technology 1").closest("div");
     fireEvent.click(button!);
 
     expect(getWindowOpenMock()).toHaveBeenCalledWith(
-      "https://reactjs.org",
+      "https://tech1.com",
       "_blank",
       "noopener,noreferrer"
     );
@@ -50,7 +50,7 @@ describe("TechnologyButton", () => {
   it("renders as clickable element", () => {
     renderWithTheme(<TechnologyButton {...mockProps} />);
 
-    const button = screen.getByText("React").closest("div");
+    const button = screen.getByText("Technology 1").closest("div");
     expect(button).toBeInTheDocument();
     expect(button).toHaveStyle({ cursor: "pointer" });
   });
@@ -58,7 +58,7 @@ describe("TechnologyButton", () => {
   it("hides icon on error", () => {
     renderWithTheme(<TechnologyButton {...mockProps} />);
 
-    const icon = screen.getByAltText("React icon") as HTMLImageElement;
+    const icon = screen.getByAltText("Technology 1 icon") as HTMLImageElement;
     fireEvent.error(icon);
 
     expect(icon.style.display).toBe("none");

--- a/src/components/projects/ProjectCard.test.tsx
+++ b/src/components/projects/ProjectCard.test.tsx
@@ -7,7 +7,7 @@ import {
 import ProjectCard from "./ProjectCard";
 
 describe("ProjectCard", () => {
-  const mockProject = mockGitHubProjects.portfolio();
+  const mockProject = mockGitHubProjects.project_1();
 
   const mockProps = {
     project: mockProject,
@@ -22,29 +22,24 @@ describe("ProjectCard", () => {
   it("displays project title", () => {
     renderWithTheme(<ProjectCard {...mockProps} />);
 
-    expect(screen.getByText("React Portfolio")).toBeInTheDocument();
+    expect(screen.getByText("GitHub Project 1")).toBeInTheDocument();
   });
 
   it("displays project description", () => {
     renderWithTheme(<ProjectCard {...mockProps} />);
 
     expect(
-      screen.getByText(
-        "A modern portfolio website built with React and TypeScript"
-      )
+      screen.getByText("GitHub Project 1 description")
     ).toBeInTheDocument();
   });
 
   it("renders project image with correct attributes", () => {
     renderWithTheme(<ProjectCard {...mockProps} />);
 
-    const image = screen.getByAltText("React Portfolio");
+    const image = screen.getByAltText("GitHub Project 1");
     expect(image).toBeInTheDocument();
-    expect(image).toHaveAttribute(
-      "src",
-      "https://example.com/portfolio-image.jpg"
-    );
-    expect(image).toHaveAttribute("alt", "React Portfolio");
+    expect(image).toHaveAttribute("src", "project1.jpg");
+    expect(image).toHaveAttribute("alt", "GitHub Project 1");
   });
 
   it("renders view project link with correct attributes", () => {
@@ -52,10 +47,7 @@ describe("ProjectCard", () => {
 
     const link = screen.getByRole("link", { name: "View Project" });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute(
-      "href",
-      "https://github.com/testuser/react-portfolio"
-    );
+    expect(link).toHaveAttribute("href", "https://project1.com");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
@@ -64,11 +56,11 @@ describe("ProjectCard", () => {
     it("opens project URL when card is clicked", () => {
       renderWithTheme(<ProjectCard {...mockProps} />);
 
-      const card = screen.getByText("React Portfolio").closest("div");
+      const card = screen.getByText("GitHub Project 1").closest("div");
       fireEvent.click(card!);
 
       expect(windowOpenMock).toHaveBeenCalledWith(
-        "https://github.com/testuser/react-portfolio",
+        "https://project1.com",
         "_blank",
         "noopener,noreferrer"
       );
@@ -88,7 +80,7 @@ describe("ProjectCard", () => {
       renderWithTheme(<ProjectCard {...mockProps} />);
 
       const card = screen
-        .getByText("React Portfolio")
+        .getByText("GitHub Project 1")
         .closest("div") as HTMLElement;
       fireEvent.mouseEnter(card);
 
@@ -100,7 +92,7 @@ describe("ProjectCard", () => {
       renderWithTheme(<ProjectCard {...mockProps} />);
 
       const card = screen
-        .getByText("React Portfolio")
+        .getByText("GitHub Project 1")
         .closest("div") as HTMLElement;
 
       // First hover to apply effects
@@ -120,7 +112,7 @@ describe("ProjectCard", () => {
 
       const titleHeading = screen.getByRole("heading", {
         level: 3,
-        name: "React Portfolio",
+        name: "GitHub Project 1",
       });
       expect(titleHeading).toBeInTheDocument();
     });
@@ -128,7 +120,7 @@ describe("ProjectCard", () => {
     it("renders main container as clickable element", () => {
       renderWithTheme(<ProjectCard {...mockProps} />);
 
-      const card = screen.getByText("React Portfolio").closest("div");
+      const card = screen.getByText("GitHub Project 1").closest("div");
       expect(card).toBeInTheDocument();
       expect(card).toHaveStyle({ cursor: "pointer" });
     });
@@ -149,7 +141,7 @@ describe("ProjectCard", () => {
     it("hides image on error", () => {
       renderWithTheme(<ProjectCard {...mockProps} />);
 
-      const image = screen.getByAltText("React Portfolio") as HTMLImageElement;
+      const image = screen.getByAltText("GitHub Project 1") as HTMLImageElement;
       fireEvent.error(image);
 
       expect(image.style.display).toBe("none");
@@ -158,7 +150,7 @@ describe("ProjectCard", () => {
     it("renders image with correct styles", () => {
       renderWithTheme(<ProjectCard {...mockProps} />);
 
-      const image = screen.getByAltText("React Portfolio");
+      const image = screen.getByAltText("GitHub Project 1");
       expect(image).toHaveStyle({
         width: "100%",
         height: "200px",

--- a/src/pages/ExperiencePage.test.tsx
+++ b/src/pages/ExperiencePage.test.tsx
@@ -60,12 +60,8 @@ describe("ExperiencePage", () => {
     renderWithTheme(<ExperiencePage {...mockProps} />);
 
     // Check for project titles and descriptions
-    expect(screen.getByText("Advanced Web Application")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Developed a complex web application using React and TypeScript with advanced features"
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText("Project 1")).toBeInTheDocument();
+    expect(screen.getByText("Project 1 description")).toBeInTheDocument();
   });
 
   it("renders academic experience projects", () => {

--- a/src/pages/ExperiencePage.test.tsx
+++ b/src/pages/ExperiencePage.test.tsx
@@ -7,7 +7,7 @@ import {
 import ExperiencePage from "./ExperiencePage";
 
 describe("ExperiencePage", () => {
-  const professionalExperience = [mockProfessionalExperience.senior()];
+  const professionalExperience = [mockProfessionalExperience.experience_1()];
   const academicExperience = [mockAcademicExperience.university()];
 
   const mockProps = {
@@ -42,8 +42,8 @@ describe("ExperiencePage", () => {
     renderWithTheme(<ExperiencePage {...mockProps} />);
 
     // Check for company names and positions
-    expect(screen.getByText("Tech Corp")).toBeInTheDocument();
-    expect(screen.getByText("Senior Software Engineer")).toBeInTheDocument();
+    expect(screen.getByText("Professional Company 1")).toBeInTheDocument();
+    expect(screen.getByText("Professional Position 1")).toBeInTheDocument();
   });
 
   it("renders all academic experience entries", () => {
@@ -97,7 +97,7 @@ describe("ExperiencePage", () => {
     renderWithTheme(<ExperiencePage {...mockProps} />);
 
     // Check for date ranges in professional experience
-    expect(screen.getByText(/2022-01\s+-\s+Present/)).toBeInTheDocument();
+    expect(screen.getByText(/01\/01\/2020\s+-\s+Present/)).toBeInTheDocument();
 
     // Check for date ranges in academic experience
     expect(screen.getByText(/2018-09\s+-\s+2022-05/)).toBeInTheDocument();

--- a/src/pages/ExperiencePage.test.tsx
+++ b/src/pages/ExperiencePage.test.tsx
@@ -8,7 +8,7 @@ import ExperiencePage from "./ExperiencePage";
 
 describe("ExperiencePage", () => {
   const professionalExperience = [mockProfessionalExperience.experience_1()];
-  const academicExperience = [mockAcademicExperience.university()];
+  const academicExperience = [mockAcademicExperience.experience_1()];
 
   const mockProps = {
     professionalExperience,
@@ -50,10 +50,8 @@ describe("ExperiencePage", () => {
     renderWithTheme(<ExperiencePage {...mockProps} />);
 
     // Check for institution names and degrees
-    expect(screen.getByText("University of Technology")).toBeInTheDocument();
-    expect(
-      screen.getByText("Bachelor of Computer Science")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Academic Institution 1")).toBeInTheDocument();
+    expect(screen.getByText("Academic Degree 1")).toBeInTheDocument();
   });
 
   it("renders professional experience projects", () => {
@@ -68,10 +66,8 @@ describe("ExperiencePage", () => {
     renderWithTheme(<ExperiencePage {...mockProps} />);
 
     // Check for project titles and descriptions
-    expect(screen.getByText("Capstone Project")).toBeInTheDocument();
-    expect(
-      screen.getByText("Machine learning application for data analysis")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Project 2")).toBeInTheDocument();
+    expect(screen.getByText("Project 2 description")).toBeInTheDocument();
   });
 
   it("has correct component structure", () => {
@@ -100,6 +96,8 @@ describe("ExperiencePage", () => {
     expect(screen.getByText(/01\/01\/2020\s+-\s+Present/)).toBeInTheDocument();
 
     // Check for date ranges in academic experience
-    expect(screen.getByText(/2018-09\s+-\s+2022-05/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/01\/01\/2018\s+-\s+01\/01\/2022/)
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -43,9 +43,9 @@ describe("HomePage", () => {
     renderWithTheme(<HomePage {...mockProps} />);
 
     // Check if technologies are rendered by looking for technology names
-    expect(screen.getByText("React")).toBeInTheDocument();
-    expect(screen.getByText("TypeScript")).toBeInTheDocument();
-    expect(screen.getByText("Node.js")).toBeInTheDocument();
+    expect(screen.getByText("Technology 1")).toBeInTheDocument();
+    expect(screen.getByText("Technology 2")).toBeInTheDocument();
+    expect(screen.getByText("Technology 3")).toBeInTheDocument();
   });
 
   it("has correct component structure", () => {

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -28,15 +28,9 @@ describe("HomePage", () => {
     renderWithTheme(<HomePage {...mockProps} />);
 
     // Check if profile summary content is rendered
-    expect(
-      screen.getByText(/I am a passionate software developer/)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/I enjoy building user-friendly applications/)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Always eager to learn new technologies/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Profile summary line 1./)).toBeInTheDocument();
+    expect(screen.getByText(/Profile summary line 2./)).toBeInTheDocument();
+    expect(screen.getByText(/Profile summary line 3./)).toBeInTheDocument();
   });
 
   it("renders TechStack component", () => {

--- a/src/pages/ProjectsPage.test.tsx
+++ b/src/pages/ProjectsPage.test.tsx
@@ -4,8 +4,8 @@ import ProjectsPage from "./ProjectsPage";
 
 describe("ProjectsPage", () => {
   const mockProjects = [
-    mockGitHubProjects.portfolio(),
-    mockGitHubProjects.ecommerce(),
+    mockGitHubProjects.project_1(),
+    mockGitHubProjects.project_2(),
   ];
 
   const mockProps = {
@@ -22,20 +22,18 @@ describe("ProjectsPage", () => {
   it("renders all project titles", () => {
     renderWithTheme(<ProjectsPage {...mockProps} />);
 
-    expect(screen.getByText("React Portfolio")).toBeInTheDocument();
-    expect(screen.getByText("E-commerce Platform")).toBeInTheDocument();
+    expect(screen.getByText("GitHub Project 1")).toBeInTheDocument();
+    expect(screen.getByText("GitHub Project 2")).toBeInTheDocument();
   });
 
   it("renders all project descriptions", () => {
     renderWithTheme(<ProjectsPage {...mockProps} />);
 
     expect(
-      screen.getByText(
-        /A modern portfolio website built with React and TypeScript/
-      )
+      screen.getByText(/GitHub Project 1 description/)
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Full-stack e-commerce solution with Node.js backend/)
+      screen.getByText(/GitHub Project 2 description/)
     ).toBeInTheDocument();
   });
 

--- a/src/test-utils/mockData.ts
+++ b/src/test-utils/mockData.ts
@@ -94,9 +94,9 @@ export const mockGitHubProjects = {
 // Complex data builders
 export const mockProfileSummary = (): ProfileSummary => ({
   description: [
-    "I am a passionate software developer with experience in modern web technologies.",
-    "I enjoy building user-friendly applications and solving complex problems.",
-    "Always eager to learn new technologies and improve my skills.",
+    "Profile summary line 1.",
+    "Profile summary line 2.",
+    "Profile summary line 3.",
   ],
 });
 

--- a/src/test-utils/mockData.ts
+++ b/src/test-utils/mockData.ts
@@ -119,25 +119,12 @@ export const mockProfessionalExperience = {
 };
 
 export const mockAcademicExperience = {
-  university: (): AcademicExperience => ({
-    institution: "University of Technology",
-    degree: "Bachelor of Computer Science",
-    startDate: "2018-09",
-    endDate: "2022-05",
-    projects: [
-      {
-        title: "Capstone Project",
-        description: "Machine learning application for data analysis",
-      },
-    ],
-  }),
-
-  college: (): AcademicExperience => ({
-    institution: "Tech College",
-    degree: "Associate Degree in Software Development",
-    startDate: "2016-09",
-    endDate: "2018-05",
-    projects: [mockProjects.project_1()],
+  experience_1: (): AcademicExperience => ({
+    institution: "Academic Institution 1",
+    degree: "Academic Degree 1",
+    startDate: "01/01/2018",
+    endDate: "01/01/2022",
+    projects: [mockProjects.project_2()],
   }),
 };
 
@@ -174,7 +161,7 @@ export const mockHomePageData = (): HomePageData => ({
 
 export const mockExperiencePageData = (): ExperiencePageData => ({
   professionalExperience: [mockProfessionalExperience.experience_1()],
-  academicExperience: [mockAcademicExperience.university()],
+  academicExperience: [mockAcademicExperience.experience_1()],
 });
 
 export const mockProjectsPageData = (): ProjectsPageData => ({

--- a/src/test-utils/mockData.ts
+++ b/src/test-utils/mockData.ts
@@ -64,15 +64,14 @@ export const mockSocialLinks = {
 };
 
 export const mockProjects = {
-  basic: (): Project => ({
-    title: "Test Project",
-    description: "A test project description",
+  project_1: (): Project => ({
+    title: "Project 1",
+    description: "Project 1 description",
   }),
 
-  detailed: (): Project => ({
-    title: "Advanced Web Application",
-    description:
-      "Developed a complex web application using React and TypeScript with advanced features",
+  project_2: (): Project => ({
+    title: "Project 2",
+    description: "Project 2 description",
   }),
 };
 
@@ -108,7 +107,7 @@ export const mockProfessionalExperience = {
     startDate: "2022-01",
     endDate: "Present",
     projects: [
-      mockProjects.detailed(),
+      mockProjects.project_1(),
       {
         title: "Project Beta",
         description: "Built a mobile app with React Native and Node.js backend",
@@ -121,7 +120,7 @@ export const mockProfessionalExperience = {
     position: "Junior Developer",
     startDate: "2021-06",
     endDate: "2021-12",
-    projects: [mockProjects.basic()],
+    projects: [mockProjects.project_2()],
   }),
 
   noProjects: (): ProfessionalExperience => ({
@@ -152,7 +151,7 @@ export const mockAcademicExperience = {
     degree: "Associate Degree in Software Development",
     startDate: "2016-09",
     endDate: "2018-05",
-    projects: [mockProjects.basic()],
+    projects: [mockProjects.project_1()],
   }),
 };
 

--- a/src/test-utils/mockData.ts
+++ b/src/test-utils/mockData.ts
@@ -101,32 +101,26 @@ export const mockProfileSummary = (): ProfileSummary => ({
 });
 
 export const mockProfessionalExperience = {
-  senior: (): ProfessionalExperience => ({
-    company: "Tech Corp",
-    position: "Senior Software Engineer",
-    startDate: "2022-01",
+  experience_1: (): ProfessionalExperience => ({
+    company: "Professional Company 1",
+    position: "Professional Position 1",
+    startDate: "01/01/2020",
     endDate: "Present",
-    projects: [
-      mockProjects.project_1(),
-      {
-        title: "Project Beta",
-        description: "Built a mobile app with React Native and Node.js backend",
-      },
-    ],
+    projects: [mockProjects.project_1()],
   }),
 
-  junior: (): ProfessionalExperience => ({
-    company: "StartUp Inc",
-    position: "Junior Developer",
-    startDate: "2021-06",
-    endDate: "2021-12",
+  experience_2: (): ProfessionalExperience => ({
+    company: "Professional Company 2",
+    position: "Professional Position 2",
+    startDate: "01/01/2019",
+    endDate: "12/31/2021",
     projects: [mockProjects.project_2()],
   }),
 
   noProjects: (): ProfessionalExperience => ({
-    company: "Test Company",
-    position: "Software Engineer",
-    startDate: "2023-01",
+    company: "No Projects Company",
+    position: "No Projects Position",
+    startDate: "01/01/2020",
     endDate: "Present",
     projects: [],
   }),
@@ -188,8 +182,8 @@ export const mockHomePageData = (): HomePageData => ({
 
 export const mockExperiencePageData = (): ExperiencePageData => ({
   professionalExperience: [
-    mockProfessionalExperience.senior(),
-    mockProfessionalExperience.junior(),
+    mockProfessionalExperience.experience_1(),
+    mockProfessionalExperience.experience_2(),
   ],
   academicExperience: [mockAcademicExperience.university()],
 });

--- a/src/test-utils/mockData.ts
+++ b/src/test-utils/mockData.ts
@@ -76,18 +76,18 @@ export const mockProjects = {
 };
 
 export const mockGitHubProjects = {
-  portfolio: (): GitHubProject => ({
-    title: "React Portfolio",
-    description: "A modern portfolio website built with React and TypeScript",
-    url: "https://github.com/testuser/react-portfolio",
-    image: "https://example.com/portfolio-image.jpg",
+  project_1: (): GitHubProject => ({
+    title: "GitHub Project 1",
+    description: "GitHub Project 1 description",
+    url: "https://project1.com",
+    image: "project1.jpg",
   }),
 
-  ecommerce: (): GitHubProject => ({
-    title: "E-commerce Platform",
-    description: "Full-stack e-commerce solution with Node.js backend",
-    url: "https://github.com/testuser/ecommerce-platform",
-    image: "https://example.com/ecommerce-image.jpg",
+  project_2: (): GitHubProject => ({
+    title: "GitHub Project 2",
+    description: "GitHub Project 2 description",
+    url: "https://project2.com",
+    image: "project2.jpg",
   }),
 };
 
@@ -195,5 +195,5 @@ export const mockExperiencePageData = (): ExperiencePageData => ({
 });
 
 export const mockProjectsPageData = (): ProjectsPageData => ({
-  projects: [mockGitHubProjects.portfolio(), mockGitHubProjects.ecommerce()],
+  projects: [mockGitHubProjects.project_1(), mockGitHubProjects.project_2()],
 });

--- a/src/test-utils/mockData.ts
+++ b/src/test-utils/mockData.ts
@@ -109,14 +109,6 @@ export const mockProfessionalExperience = {
     projects: [mockProjects.project_1()],
   }),
 
-  experience_2: (): ProfessionalExperience => ({
-    company: "Professional Company 2",
-    position: "Professional Position 2",
-    startDate: "01/01/2019",
-    endDate: "12/31/2021",
-    projects: [mockProjects.project_2()],
-  }),
-
   noProjects: (): ProfessionalExperience => ({
     company: "No Projects Company",
     position: "No Projects Position",
@@ -181,10 +173,7 @@ export const mockHomePageData = (): HomePageData => ({
 });
 
 export const mockExperiencePageData = (): ExperiencePageData => ({
-  professionalExperience: [
-    mockProfessionalExperience.experience_1(),
-    mockProfessionalExperience.experience_2(),
-  ],
+  professionalExperience: [mockProfessionalExperience.experience_1()],
   academicExperience: [mockAcademicExperience.university()],
 });
 

--- a/src/test-utils/mockData.ts
+++ b/src/test-utils/mockData.ts
@@ -17,49 +17,49 @@ import {
  */
 
 // Base mock data builders
-export const mockSocialLinks = {
-  github: (): SocialLink => ({
-    name: "GitHub",
-    url: "https://github.com/testuser",
-    icon: "github.svg",
+export const mockTechnologies = {
+  tech_1: (): Technology => ({
+    name: "Technology 1",
+    url: "https://tech1.com",
+    icon: "tech1.svg",
   }),
 
-  linkedin: (): SocialLink => ({
-    name: "LinkedIn",
-    url: "https://linkedin.com/in/testuser",
-    icon: "linkedin.svg",
+  tech_2: (): Technology => ({
+    name: "Technology 2",
+    url: "https://tech2.com",
+    icon: "tech2.svg",
   }),
 
-  twitter: (): SocialLink => ({
-    name: "Twitter",
-    url: "https://twitter.com/testuser",
-    icon: "twitter.svg",
+  tech_3: (): Technology => ({
+    name: "Technology 3",
+    url: "https://tech3.com",
+    icon: "tech3.svg",
+  }),
+
+  tech_4: (): Technology => ({
+    name: "Technology 4",
+    url: "https://tech4.com",
+    icon: "tech4.svg",
   }),
 };
 
-export const mockTechnologies = {
-  react: (): Technology => ({
-    name: "React",
-    url: "https://reactjs.org",
-    icon: "https://example.com/react-icon.svg",
+export const mockSocialLinks = {
+  link_1: (): SocialLink => ({
+    name: "Link 1",
+    url: "https://link1.com",
+    icon: "link1.svg",
   }),
 
-  typescript: (): Technology => ({
-    name: "TypeScript",
-    url: "https://typescriptlang.org",
-    icon: "https://example.com/typescript-icon.svg",
+  link_2: (): SocialLink => ({
+    name: "Link 2",
+    url: "https://link2.com",
+    icon: "link2.svg",
   }),
 
-  nodejs: (): Technology => ({
-    name: "Node.js",
-    url: "https://nodejs.org",
-    icon: "https://example.com/nodejs-icon.svg",
-  }),
-
-  javascript: (): Technology => ({
-    name: "JavaScript",
-    url: "https://developer.mozilla.org/en-US/docs/Web/JavaScript",
-    icon: "https://example.com/javascript-icon.svg",
+  link_3: (): SocialLink => ({
+    name: "Link 3",
+    url: "https://link3.com",
+    icon: "link3.svg",
   }),
 };
 
@@ -156,19 +156,35 @@ export const mockAcademicExperience = {
   }),
 };
 
+// Array builders for common scenarios
+export const createMockTechnologies = (count: number = 3): Technology[] => {
+  const technologies = [
+    mockTechnologies.tech_1(),
+    mockTechnologies.tech_2(),
+    mockTechnologies.tech_3(),
+    mockTechnologies.tech_4(),
+  ];
+  return technologies.slice(0, count);
+};
+
+export const createMockSocialLinks = (count: number = 2): SocialLink[] => {
+  const links = [
+    mockSocialLinks.link_1(),
+    mockSocialLinks.link_2(),
+    mockSocialLinks.link_3(),
+  ];
+  return links.slice(0, count);
+};
+
 // Full page data builders
 export const mockAppData = (): AppData => ({
   appHeaderText: "Test Portfolio",
-  socialLinks: [mockSocialLinks.github(), mockSocialLinks.linkedin()],
+  socialLinks: createMockSocialLinks(3),
 });
 
 export const mockHomePageData = (): HomePageData => ({
   profileSummary: mockProfileSummary(),
-  technologies: [
-    mockTechnologies.react(),
-    mockTechnologies.typescript(),
-    mockTechnologies.nodejs(),
-  ],
+  technologies: createMockTechnologies(4),
 });
 
 export const mockExperiencePageData = (): ExperiencePageData => ({
@@ -182,23 +198,3 @@ export const mockExperiencePageData = (): ExperiencePageData => ({
 export const mockProjectsPageData = (): ProjectsPageData => ({
   projects: [mockGitHubProjects.portfolio(), mockGitHubProjects.ecommerce()],
 });
-
-// Array builders for common scenarios
-export const createMockTechnologies = (count: number = 3): Technology[] => {
-  const technologies = [
-    mockTechnologies.react(),
-    mockTechnologies.typescript(),
-    mockTechnologies.nodejs(),
-    mockTechnologies.javascript(),
-  ];
-  return technologies.slice(0, count);
-};
-
-export const createMockSocialLinks = (count: number = 2): SocialLink[] => {
-  const links = [
-    mockSocialLinks.github(),
-    mockSocialLinks.linkedin(),
-    mockSocialLinks.twitter(),
-  ];
-  return links.slice(0, count);
-};


### PR DESCRIPTION
This pull request updates test cases across multiple components to use generic placeholder data instead of specific real-world examples. The changes aim to make the tests more reusable and less tied to specific entities or values. Below is a summary of the most important changes grouped by theme.

### Updates to Social Links and Footer Tests:
* Replaced specific social link names like "GitHub," "LinkedIn," and "Twitter" with generic placeholders "Link 1," "Link 2," and "Link 3" in `src/App.test.tsx` and `src/components/common/Footer.test.tsx`. Updated corresponding href attributes to use placeholder URLs [[1]](diffhunk://#diff-20c86208e27d2f9659751b9824586495f177d8b41fc5a6a9c7ec0f5842788f90L33-R35) [[2]](diffhunk://#diff-20c86208e27d2f9659751b9824586495f177d8b41fc5a6a9c7ec0f5842788f90L90-R101) [[3]](diffhunk://#diff-435f0f4f350c5bb36f337552a98c9d938d8018cd5eb2aa0e5709f4dc0e071b59L15-R29).

### Updates to Experience Panel Tests:
* Replaced specific professional and academic experience data (e.g., "Tech Corp," "University of Technology") with generic placeholders like "Professional Company 1" and "Academic Institution 1" in `src/components/experience/ExperiencePanel.test.tsx`. Updated associated projects, positions, and date ranges to use generic placeholder values [[1]](diffhunk://#diff-24a69c6f3c6a806b41c1c98eb9c8b5030c0dc4b6e997ca8f927b4035987d9105L24-R43) [[2]](diffhunk://#diff-24a69c6f3c6a806b41c1c98eb9c8b5030c0dc4b6e997ca8f927b4035987d9105L58-R55) [[3]](diffhunk://#diff-24a69c6f3c6a806b41c1c98eb9c8b5030c0dc4b6e997ca8f927b4035987d9105L73-R88).

### Updates to Technology Button and Tech Stack Tests:
* Replaced specific technology names (e.g., "React," "TypeScript") with placeholders like "Technology 1" and updated associated icons and URLs in `src/components/home/TechnologyButton.test.tsx` and `src/components/home/TechStack.test.tsx` [[1]](diffhunk://#diff-ef58c73f685f5fda57f6b3a4832a228f5e6bc45234ebeab25066cdd531f8353dL25-R44) [[2]](diffhunk://#diff-8b95febee27d5d13826459bfb83a4d6483aaf82d7351b187708c8a14f008c037L31-R33).

### Updates to Project Card Tests:
* Replaced specific project details (e.g., "React Portfolio") with placeholders like "GitHub Project 1" in `src/components/projects/ProjectCard.test.tsx`. Updated associated descriptions, images, and URLs to use generic placeholders [[1]](diffhunk://#diff-32abdb4a02c0343fba671b490357752847b2e382c059df2eddf2d1cbe39b8112L25-R50) [[2]](diffhunk://#diff-32abdb4a02c0343fba671b490357752847b2e382c059df2eddf2d1cbe39b8112L67-R63).

### Updates to Profile Summary Tests:
* Replaced specific profile summary text (e.g., "I am a passionate software developer") with generic placeholder lines like "Profile summary line 1." in `src/components/home/ProfileSummaryDisplay.test.tsx`.